### PR TITLE
Add API logging middleware to express server setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Dependency directories
 node_modules/
+api_logs.txt
 
 .env
 

--- a/src/helper/apiCallLog.js
+++ b/src/helper/apiCallLog.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+
+// Middleware function to log API calls
+function apiLogger(req, res, next) {
+  const { method, url, body } = req;
+  const metadata = {
+    route: req.originalUrl,
+    buttonClicked: req.headers['button-clicked'],
+    // Add more metadata as needed
+  };
+  const logData = {
+    timestamp: new Date().toISOString(),
+    method,
+    url,
+    metadata,
+    body,
+  };
+  const logString = JSON.stringify(logData);
+
+  // Write log to file
+  fs.appendFile('api_logs.txt', logString + '\n', (err) => {
+    if (err) {
+      console.error('Error writing log:', err);
+    }
+  });
+
+  next();
+}
+
+module.exports = apiLogger;

--- a/src/index.js
+++ b/src/index.js
@@ -4,8 +4,9 @@ const cors = require("cors");
 const functions = require("firebase-functions");
 const { initializeApp, cert } = require("firebase-admin/app");
 const fileUploader = require("express-fileupload");
-const serviceAccount = require("../creator-99ddf-firebase-adminsdk-nf38h-cc33e2ec46.json");
+const serviceAccount = require("../contentisqueen-97ae5-firebase-adminsdk-qhkbo-6886ee17eb.json");
 const router = require("./restful/routes");
+const apiLogger = require("./helper/apiCallLog");
 
 dotenv.config();
 const PORT = 5000;
@@ -16,6 +17,7 @@ initializeApp({
   credential: cert(serviceAccount),
   storageBucket: "contentisqueen-97ae5.appspot.com",
 });
+app.use(apiLogger);
 app.use(
   fileUploader({
     fileSize: 50 * 1024 * 1024,


### PR DESCRIPTION
**Implement API logging middleware in the Express server setup**

This commit adds the apiLogger middleware to the Express server setup. The middleware logs each API call to a file and includes metadata such as the route and button clicked. This enhances the server's logging capabilities and provides valuable information for debugging and monitoring purposes.

#69 