### PR TITLE
Add validation to createOpportunity method Validating posting opportunities #109

### DIFF
--- a/src/restful/controllers/opportunitiesController.js
+++ b/src/restful/controllers/opportunitiesController.js
@@ -246,60 +246,60 @@ class OpportunitiesController {
   static async createOpportunity(req, res, type) {
     const db = admin.firestore();
     try {
-      // Generate UUID for opportunity_id
-      const opportunity_id = uuidv4();
+        // Generate UUID for opportunity_id
+        const opportunity_id = uuidv4();
 
-      // Extract opportunity data from request body
-      const { ...opportunityData } = req.body;
+        // Extract opportunity data from request body
+        const { ...opportunityData } = req.body;
 
-      // Set default status to "open" if not provided
-      // eslint-disable-next-line no-prototype-builtins
-      if (!opportunityData.hasOwnProperty("status")) {
-        opportunityData.status = "open";
-      }
+        // Set default status to "open" if not provided
+        if (!opportunityData.hasOwnProperty("status")) {
+            opportunityData.status = "open";
+        }
 
-      // Validate required fields
-      const requiredFields = getRequiredFields(type);
-      const isValid = requiredFields.every((field) =>
-        Object.prototype.hasOwnProperty.call(opportunityData, field),
-      );
-      if (!isValid) {
-        util.statusCode = 400;
-        util.message = `Missing or invalid fields for ${type} opportunity`;
+        // Validate required fields
+        const requiredFields = getRequiredFields(type);
+        const isValid = requiredFields.every((field) =>
+            Object.prototype.hasOwnProperty.call(opportunityData, field) && opportunityData[field].trim() !== ""
+        );
+        if (!isValid) {
+            util.statusCode = 400;
+            util.message = `Missing or invalid fields for ${type} opportunity`;
+            return util.send(res);
+        }
+
+        // Check if opportunity with same ID already exists
+        const existingOpportunity = await db
+            .collection("opportunities")
+            .doc(opportunity_id)
+            .get();
+        if (existingOpportunity.exists) {
+            util.statusCode = 400;
+            util.message = "Opportunity with same ID already exists";
+            return util.send(res);
+        }
+
+        // Store the opportunity data in the opportunities collection
+        await db
+            .collection("opportunities")
+            .doc(opportunity_id)
+            .set({
+                opportunity_id,
+                type,
+                ...opportunityData,
+            });
+
+        util.statusCode = 201;
+        util.message = "Opportunity created successfully";
         return util.send(res);
-      }
-
-      // Check if opportunity with same ID already exists
-      const existingOpportunity = await db
-        .collection("opportunities")
-        .doc(opportunity_id)
-        .get();
-      if (existingOpportunity.exists) {
-        util.statusCode = 400;
-        util.message = "Opportunity with same ID already exists";
-        return util.send(res);
-      }
-
-      // Store the opportunity data in the opportunities collection
-      await db
-        .collection("opportunities")
-        .doc(opportunity_id)
-        .set({
-          opportunity_id,
-          type,
-          ...opportunityData,
-        });
-
-      util.statusCode = 201;
-      util.message = "Opportunity created successfully";
-      return util.send(res);
     } catch (error) {
-      console.error(error);
-      util.statusCode = 500;
-      util.message = error.message || "Server error";
-      return util.send(res);
+        console.error(error);
+        util.statusCode = 500;
+        util.message = error.message || "Server error";
+        return util.send(res);
     }
-  }
+}
+
 
   static async createJobOpportunity(req, res) {
     return OpportunitiesController.createOpportunity(req, res, "job");


### PR DESCRIPTION

We shouldn't be able to POST an opportunity if any of the fields are empty. Whilst this will also be handle on the frontend, it should be impossible for it to bypass the backend.

