### PR TITLE
Fix error while getting user id

### DIFF
--- a/src/restful/controllers/authController.js
+++ b/src/restful/controllers/authController.js
@@ -269,7 +269,8 @@ class AuthController {
         last_name: userData.last_name,
         role: userData.role,
         imageUrl: userData.imageUrl, // Assuming this field exists in the user document
-        bio: userData.bio, // Assuming this field exists in the user document
+        bio: userData.bio,
+        uid: userData.uid, // Assuming this field exists in the user document
       };
 
       util.statusCode = 200;


### PR DESCRIPTION
## Describe your changes
#150 

We need the ID of a user to be provided for GET requests, as this is used to get their profile data. Such as opportunities
