### PR TITLE
Add middleware to check the paid user accounts.

### DIFF
--- a/src/helper/checkSubscribedUser.js
+++ b/src/helper/checkSubscribedUser.js
@@ -1,0 +1,48 @@
+const admin = require("firebase-admin");
+const { Util } = require("./utils");
+
+const util = new Util();
+
+const checkSubscribedUser = () => {
+  return async (req, res, next) => {
+    const db = admin.firestore();
+    const userRole = req.user.role;
+    const limitsRef = db.collection("settings").doc("limits");
+    if (userRole === "admin" || userRole === "super_admin") {
+      return next();
+    } else if (req.user.subscribed) {
+      return next();
+    } else if (userRole === "brand") {
+      const numberOfOpportunitiesAllowedSnapshot = await limitsRef.get();
+      const { numberOfOpportunitiesAllowed } =
+        numberOfOpportunitiesAllowedSnapshot.data();
+      const { opportunitiesPostedCount } = req.body;
+      if (opportunitiesPostedCount > numberOfOpportunitiesAllowed) {
+        util.statusCode = 403;
+        util.message =
+          "Number of opportunities allowed for unpaid accounts has been reached";
+        return util.send(res);
+      } else {
+        return next();
+      }
+    } else if (userRole === "creator") {
+      const numberOfApplicationsAllowedSnapshot = await limitsRef.get();
+      const { numberOfApplicationsAllowed } =
+        numberOfApplicationsAllowedSnapshot.data();
+      const { opportunitiesAppliedCount } = req.body;
+      if (opportunitiesAppliedCount > numberOfApplicationsAllowed) {
+        util.statusCode = 403;
+        util.message =
+          "Number of applications allowed for unpaid accounts has been reached";
+        return util.send(res);
+      } else {
+        return next();
+      }
+    } else {
+      util.statusCode = 400;
+      util.message = "You are not allowed to perform this action";
+      return util.send(res);
+    }
+  };
+};
+module.exports = checkSubscribedUser;

--- a/src/restful/controllers/adminController.js
+++ b/src/restful/controllers/adminController.js
@@ -344,6 +344,38 @@ class AdminController {
       return util.send(res);
     }
   }
+
+  static async addNumberOfAccountLimits(req, res) {
+    const db = admin.firestore();
+    try {
+      const { numberOfApplicationsAllowed, numberOfOpportunitiesAllowed } =
+        req.body;
+      if (
+        numberOfApplicationsAllowed === undefined &&
+        numberOfOpportunitiesAllowed === undefined
+      ) {
+        return res
+          .status(400)
+          .json({ message: "No valid fields provided for update" });
+      }
+      const updateData = {};
+      if (numberOfApplicationsAllowed !== undefined) {
+        updateData.numberOfApplicationsAllowed = numberOfApplicationsAllowed;
+      }
+      if (numberOfOpportunitiesAllowed !== undefined) {
+        updateData.numberOfOpportunitiesAllowed = numberOfOpportunitiesAllowed;
+      }
+      const settingsRef = db.collection("settings").doc("limits");
+      await settingsRef.set(updateData, { merge: true });
+      util.statusCode = 200;
+      util.message = "Settings updated successfully";
+      return util.send(res);
+    } catch (error) {
+      util.statusCode = 500;
+      util.message = error.message || "Error updating settings";
+      return util.send(res);
+    }
+  }
 }
 
 exports.AdminController = AdminController;

--- a/src/restful/controllers/adminController.js
+++ b/src/restful/controllers/adminController.js
@@ -45,7 +45,7 @@ class AdminController {
         disabled: false,
       };
       if (role === "admin" || role === "super_admin") {
-        userData.organization = db.doc("organizationInfo/ciq");
+        userData.organization = db.doc("settings/organization");
       }
 
       await usersCollectionRef.doc(user.uid).set(userData);
@@ -297,7 +297,7 @@ class AdminController {
   static async getCompanyInfo(req, res) {
     try {
       const db = admin.firestore();
-      const ciQRef = db.collection("organizationInfo").doc("ciq");
+      const ciQRef = db.collection("settings").doc("organization");
       const userDoc = await ciQRef.get();
       util.setSuccess(200, userDoc.data());
       return util.send(res);
@@ -317,7 +317,7 @@ class AdminController {
         return util.send(res);
       }
       const db = admin.firestore();
-      const ciQRef = db.collection("organizationInfo").doc("ciq");
+      const ciQRef = db.collection("settings").doc("organization");
       const updateData = {};
 
       if (organizationName) {

--- a/src/restful/controllers/authController.js
+++ b/src/restful/controllers/authController.js
@@ -184,14 +184,14 @@ class AuthController {
       if (docSnapshot.exists) {
         const userData = docSnapshot.data();
         if (role === "super_admin" || role === "admin") {
-          const organizationInfoRef = userData?.organization;
-          if (organizationInfoRef) {
-            const organizationInfoSnapshot = await organizationInfoRef?.get();
-            if (organizationInfoSnapshot.exists) {
+          const settingsRef = userData?.organization;
+          if (settingsRef) {
+            const settingsSnapshot = await settingsRef?.get();
+            if (settingsSnapshot.exists) {
               userData.organizationName =
-                organizationInfoSnapshot.data().organizationName;
+                settingsSnapshot.data().organizationName;
               userData.organizationLogo =
-                organizationInfoSnapshot.data().organizationLogo;
+                settingsSnapshot.data().organizationLogo;
             }
           }
         }
@@ -229,14 +229,14 @@ class AuthController {
 
       const userData = querySnapshot.data();
       if (userData.role === "super_admin" || userData.role === "admin") {
-        const organizationInfoRef = userData?.organization;
-        if (organizationInfoRef) {
-          const organizationInfoSnapshot = await organizationInfoRef?.get();
-          if (organizationInfoSnapshot.exists) {
+        const settingsRef = userData?.organization;
+        if (settingsRef) {
+          const settingsSnapshot = await settingsRef?.get();
+          if (settingsSnapshot.exists) {
             userData.organizationName =
-              organizationInfoSnapshot.data().organizationName;
+              settingsSnapshot.data().organizationName;
             userData.organizationLogo =
-              organizationInfoSnapshot.data().organizationLogo;
+              settingsSnapshot.data().organizationLogo;
           }
         }
       }
@@ -284,14 +284,14 @@ class AuthController {
         for (const doc of querySnapshot.docs) {
           const userObj = doc.data();
           if (userObj.role === "super_admin" || userObj.role === "admin") {
-            const organizationInfoRef = userObj?.organization;
-            if (organizationInfoRef) {
-              const organizationInfoSnapshot = await organizationInfoRef?.get();
-              if (organizationInfoSnapshot.exists) {
+            const settingsRef = userObj?.organization;
+            if (settingsRef) {
+              const settingsSnapshot = await settingsRef?.get();
+              if (settingsSnapshot.exists) {
                 userObj.organizationName =
-                  organizationInfoSnapshot.data().organizationName;
+                  settingsSnapshot.data().organizationName;
                 userObj.organizationLogo =
-                  organizationInfoSnapshot.data().organizationLogo;
+                  settingsSnapshot.data().organizationLogo;
               }
             }
           }

--- a/src/restful/controllers/opportunitiesController.js
+++ b/src/restful/controllers/opportunitiesController.js
@@ -350,7 +350,7 @@ class OpportunitiesController {
         opportunityData.company = userData.organizationName || null;
       }
       if (userData.role === "admin" || userData.role === "super_admin") {
-        const adminRef = db.collection("organizationInfo").doc("ciq");
+        const adminRef = db.collection("settings").doc("organization");
         opportunityData.profileCompanyPhotoRef = adminRef;
       } else {
         opportunityData.profilePhotoRef = userRef;

--- a/src/restful/routes/adminRouter.js
+++ b/src/restful/routes/adminRouter.js
@@ -47,5 +47,11 @@ router.patch(
 router.get("/opportunities", AdminController.getAllOpportunities);
 router.get("/company", AdminController.getCompanyInfo);
 router.put("/company", AdminController.updateCompanyInfo);
+router.put(
+  "/limits",
+  protect,
+  allowedRole(["super_admin"]),
+  AdminController.addNumberOfAccountLimits,
+);
 
 module.exports.adminRouter = router;

--- a/src/restful/routes/applicationsRouter.js
+++ b/src/restful/routes/applicationsRouter.js
@@ -2,6 +2,8 @@ const { Router } = require("express");
 const {
   ApplicationsController,
 } = require("../controllers/applicationsController");
+const { protect } = require("../../middleware");
+const checkSubscribedUser = require("../../helper/checkSubscribedUser");
 
 const router = Router();
 
@@ -18,7 +20,12 @@ router.get(
 router.get("/:applicationId", ApplicationsController.getApplicationById);
 
 // POST a new application
-router.post("/", ApplicationsController.createApplication);
+router.post(
+  "/",
+  protect,
+  checkSubscribedUser(),
+  ApplicationsController.createApplication,
+);
 
 // PATCH update an existing application
 router.patch("/:applicationId", ApplicationsController.updateApplication);

--- a/src/restful/routes/opportunitiesRouter.js
+++ b/src/restful/routes/opportunitiesRouter.js
@@ -2,6 +2,8 @@ const { Router } = require("express");
 const {
   OpportunitiesController,
 } = require("../controllers/opportunitiesController");
+const { protect } = require("../../middleware");
+const checkSubscribedUser = require("../../helper/checkSubscribedUser");
 
 const router = Router();
 
@@ -18,7 +20,7 @@ router.get(
 );
 
 // POST endpoint for creating opportunities
-router.post("/", async (req, res) => {
+router.post("/", protect, checkSubscribedUser(), async (req, res) => {
   const { type } = req.body;
   if (!type || !["job", "pitch", "campaign"].includes(type)) {
     return res


### PR DESCRIPTION
Step 1: The super admin will set the number of posts and applications an unsubscribed user can make.
Step 2: Ensure that the data set by the admin is stored in the database.
Step 3: Record each post or application the user has created in the user's collection.
Step 4: Before each post or application, add a middleware to check if the user has subscribed.
Step 5: If the user has subscribed, allow posting. If the user has not subscribed, retrieve the remaining posts from the user's collection and the number of allowed posts from the credit or settings collection. If the user is running out of posts, request them to subscribe before posting. 


**Post opportunities sample**
Add one extra field called  `opportunitiesPostedCount` from user profile

**Create application sample**
Add one extra field called  `opportunitiesPostedCount`  from user profile

**Supper Admin Update limits**
```
{
    "numberOfApplicationsAllowed": 5000,
    "numberOfOpportunitiesAllowed": 10
}
```



![image](https://github.com/content-is-queen/creator-platform-be/assets/52130946/1b7c42ee-fde5-4bf4-b3bd-aad3454b8a35)
